### PR TITLE
Update build.gradle

### DIFF
--- a/gradle-bintray-plugin-examples/configurations-example/build.gradle
+++ b/gradle-bintray-plugin-examples/configurations-example/build.gradle
@@ -53,6 +53,21 @@ bintray {
 	}
 }
 
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
 task wrapper(type: Wrapper) {
   gradleVersion = '2.4'
 }


### PR DESCRIPTION
with the added code it also generates *-sources.jar and *-docs.jar . I am new with Bintray but I had the surprise of package rejection because of missing sources & docs. That code is from http://stackoverflow.com/questions/11474729/how-to-build-sources-jar-with-gradle and it was given to be by someone from support, telling me to add the missing jars.